### PR TITLE
Configure CircleCI to use the Gradle wrapper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: gradle dependencies
+      - run: ~/gradlew dependencies
 
       - save_cache:
           paths:
@@ -39,7 +39,7 @@ jobs:
           key: v1-dependencies-{{ checksum "build.gradle" }}
         
       # run tests!
-      - run: gradle test
+      - run: ~/gradlew test
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: ~/gradlew dependencies
+      - run: ~/repo/gradlew dependencies
 
       - save_cache:
           paths:
@@ -39,7 +39,7 @@ jobs:
           key: v1-dependencies-{{ checksum "build.gradle" }}
         
       # run tests!
-      - run: ~/gradlew test
+      - run: ~/repo/gradlew test
 
 
 


### PR DESCRIPTION
Previously, the newest version of Gradle was being used by CircleCI. This is a problem because Gradle 5.0 just released, and one of the changes is the removal of the leftShift operator for closures. This is used within our Gradle build file, so we should use the wrapper for the best compatibility with our project.